### PR TITLE
Expand listed short args before handling args.

### DIFF
--- a/ls/src/main.rs
+++ b/ls/src/main.rs
@@ -133,7 +133,7 @@ fn main() {
     let args: Vec<String> = env::args().collect();
     let mut expanded_args: Vec<String> = Vec::new();
     for arg in args.iter().skip(1) {
-        if arg.len() > 1 && arg.starts_with('-') {
+        if arg.len() > 2 && arg.starts_with('-') && !arg.starts_with("--") {
             for ch in arg.chars().skip(1) {
                 expanded_args.push(format!("-{}", ch));
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Combined short flags are now supported: group multiple single-letter options into a single argument (e.g., -abc behaves like -a -b -c).
  * Flags are parsed before positional directory arguments, improving reliability when mixing options and paths.
  * Long-form flags continue to work as before; non-flag arguments are treated as directories.

* **Bug Fixes**
  * Parsing now stops on unknown arguments, ensuring consistent error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->