### PR TITLE
#19 - On Windows just call `cls` and fallback to Unix based print if fails

### DIFF
--- a/clear/src/main.rs
+++ b/clear/src/main.rs
@@ -1,3 +1,5 @@
+use std::io::{self, Write};
+
 #[cfg(windows)]
 use std::process::Command;
 
@@ -16,4 +18,5 @@ fn main() {
     }
 
     print!("\x1B[2J\x1B[1;1H");
+    io::stdout().flush().ok();
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen clearing on Windows by using the platform's native clearing mechanism for more reliable behavior; if that method isn't available it falls back to the existing ANSI escape-based clearing. Non-Windows platforms continue to use ANSI sequences for screen clearing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->